### PR TITLE
[FIX] fix form initial props

### DIFF
--- a/src/createField.js
+++ b/src/createField.js
@@ -24,7 +24,8 @@ const mapStateToProps = (state, props) => {
   const formId = props.form.getFormId();
   const fieldNames = getFieldNames(props.name);
   const selector = createSelector(state, formId);
-  const form = selector.getForm() || initialState.form;
+  const formState = selector.getForm();
+  const form = (formState && Object.keys(formState).length) || initialState.form;
   const field = selector.getField(fieldNames) || initialState.field;
 
   return {


### PR DESCRIPTION
previously when `selector.getForm()` called it will return empty object when when it can't find requested form id in the state, therefore it can't get the `initialState.form` because `{} || initialState.form` will always returned `{}`