### PR TITLE
[FIX] removed item in createRepeatable will re-init when submit is invoked

### DIFF
--- a/src/_createForm.js
+++ b/src/_createForm.js
@@ -67,10 +67,11 @@ export const __createForm = (fields, fieldNames) => (formId, dispatch) => {
     unregField: fieldNames => {
       delete __fields[fieldNames];
       const index = __fieldNames.findIndex(
-        __fieldNames => __fieldNames.some(__fieldName => (
-          fieldNames.some(fieldName => __fieldName === fieldName)
-        ))
-      );
+        __fieldNames => (
+          __fieldNames.length === fieldNames.length &&
+          __fieldNames.every((name, i) => name === fieldNames[i])
+        ));
+
       if (index !== -1) {
         __fieldNames.splice(index, 1);
       }

--- a/test/__snapshots__/_createForm.test.js.snap
+++ b/test/__snapshots__/_createForm.test.js.snap
@@ -453,12 +453,37 @@ Object {
       Array [
         "bar",
       ],
+      Array [
+        "foo",
+        "bar",
+      ],
+      Array [
+        "foo",
+        "bar",
+        "bar",
+        0,
+      ],
+      Array [
+        "foo",
+        "bar",
+        0,
+        "bar",
+      ],
     ],
     "fields": Object {
       "bar": Object {
         "validateAll": [Function],
       },
       "foo": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar,0,bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar,bar,0": Object {
         "validateAll": [Function],
       },
     },
@@ -468,9 +493,181 @@ Object {
       Array [
         "bar",
       ],
+      Array [
+        "foo",
+        "bar",
+      ],
+      Array [
+        "foo",
+        "bar",
+        "bar",
+        0,
+      ],
+      Array [
+        "foo",
+        "bar",
+        0,
+        "bar",
+      ],
     ],
     "fields": Object {
       "bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar,0,bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar,bar,0": Object {
+        "validateAll": [Function],
+      },
+    },
+  },
+}
+`;
+
+exports[`form should unregister a field 2`] = `
+Object {
+  "_previous": Object {
+    "fieldNames": Array [
+      Array [
+        "foo",
+      ],
+      Array [
+        "bar",
+      ],
+      Array [
+        "foo",
+        "bar",
+      ],
+      Array [
+        "foo",
+        "bar",
+        "bar",
+        0,
+      ],
+      Array [
+        "foo",
+        "bar",
+        0,
+        "bar",
+      ],
+    ],
+    "fields": Object {
+      "bar": Object {
+        "validateAll": [Function],
+      },
+      "foo": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar,0,bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar,bar,0": Object {
+        "validateAll": [Function],
+      },
+    },
+  },
+  "current": Object {
+    "fieldNames": Array [
+      Array [
+        "bar",
+      ],
+      Array [
+        "foo",
+        "bar",
+        "bar",
+        0,
+      ],
+      Array [
+        "foo",
+        "bar",
+        0,
+        "bar",
+      ],
+    ],
+    "fields": Object {
+      "bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar,0,bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar,bar,0": Object {
+        "validateAll": [Function],
+      },
+    },
+  },
+}
+`;
+
+exports[`form should unregister a field 3`] = `
+Object {
+  "_previous": Object {
+    "fieldNames": Array [
+      Array [
+        "foo",
+      ],
+      Array [
+        "bar",
+      ],
+      Array [
+        "foo",
+        "bar",
+      ],
+      Array [
+        "foo",
+        "bar",
+        "bar",
+        0,
+      ],
+      Array [
+        "foo",
+        "bar",
+        0,
+        "bar",
+      ],
+    ],
+    "fields": Object {
+      "bar": Object {
+        "validateAll": [Function],
+      },
+      "foo": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar,0,bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar,bar,0": Object {
+        "validateAll": [Function],
+      },
+    },
+  },
+  "current": Object {
+    "fieldNames": Array [
+      Array [
+        "bar",
+      ],
+      Array [
+        "foo",
+        "bar",
+        "bar",
+        0,
+      ],
+    ],
+    "fields": Object {
+      "bar": Object {
+        "validateAll": [Function],
+      },
+      "foo,bar,bar,0": Object {
         "validateAll": [Function],
       },
     },

--- a/test/_createForm.test.js
+++ b/test/_createForm.test.js
@@ -131,19 +131,23 @@ describe('form', () => {
   it('should unregister a field', () => {
     form.regField(['foo'], jest.fn());
     form.regField(['bar'], jest.fn());
+    form.regField(['foo', 'bar'], jest.fn());
+    form.regField(['foo', 'bar', 'bar', 0], jest.fn());
+    form.regField(['foo', 'bar', 0, 'bar'], jest.fn());
+
     const _previous = {
       fields: { ...fields },
       fieldNames: [...fieldNames],
     };
     form.unregField(['foo']);
     form.unregField(['foo']);
-    expect({
-      _previous,
-      current: {
-        fields,
-        fieldNames,
-      },
-    }).toMatchSnapshot();
+    expect({ _previous, current: { fields, fieldNames }}).toMatchSnapshot();
+
+    form.unregField(['foo', 'bar']);
+    expect({ _previous, current: { fields, fieldNames }}).toMatchSnapshot();
+
+    form.unregField(['foo', 'bar', 0, 'bar']);
+    expect({ _previous, current: { fields, fieldNames }}).toMatchSnapshot();
   });
 
   it('should validate all registered fields', async () => {


### PR DESCRIPTION
**Issue:** 
In createRepeatable, when an repeatable item is removed and then submit, the form will re-init the deleted repeatable item with empty value.

**Cause:**
caused by incorrect item in __fieldNames is deleted when unregField function is called from createField's componentWilUnmount. this causes `dispatch(clearErrorMessages(formId, __fieldNames));` in `submit` method to re-init the items again.

**Fix:**
comparison logic in unregField should be exactly the same, instead of partially equal `['foo', 'bar' 0, 'bar'] !== ['foo', 'bar', 'bar', 0]`