### PR TITLE
Feature: add parseValue props to createField

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,7 +7,42 @@ Create a field component that connects to the form component above.
 - `Component` *(ReactComponent)*: React component to be created as field component.
 
 ### Returns
-*(ReactComponent)*: Field component that passes the following props:
+*(ReactComponent)*
+
+#### Accepts the following props
+- `parseValue: (value) => parsedValue [Optional]`: Parses the value given from the field input component to the type that you want when submitting the form. Example of the use case: parse string to number, timestamp to localized date format, or extract an field from object.
+
+```js
+import React from 'react';
+import { createForm, createField } from 'soya-form';
+
+const Field = createField((props) => <input type="text" value={props.value} />);
+
+class Form extends React.Component {
+  componentDidMount() {
+    this.form.setValue('testField', 3.14);
+  }
+
+  handleSubmit = () => {
+    this.props.form.submit(({ values }) => {
+      console.log(values.testField); // this will return 3;
+    })
+  }
+
+  render() {
+    return (
+      <div>
+        <Field name={'testField'} form={props.form} parseValue={(value) => Math.floor(Number(value)) }/>
+        <button onClick={handleSubmit}>Submit</button>
+      </div>
+    );
+  }
+)};
+
+export default createForm('FORM')(Form);
+```
+
+#### Return the following props
 - `value` *(Any)*: Current value of the field.
 ```js
 import { createField } from 'soya-form';

--- a/src/_createField.js
+++ b/src/_createField.js
@@ -42,6 +42,7 @@ export default Component => {
       changeValidators: [],
       asyncValidators: [],
       submitValidators: [],
+      parseValue: value => value,
     };
 
     constructor(props, context) {
@@ -114,11 +115,19 @@ export default Component => {
         ...this.__submitValidators,
       ];
       const errorMessages = createValidate(validators)(this.props.value);
-      const createResult = isValid => ({
-        isValid,
-        value: this.props.value,
-        name: this.props.name,
-      });
+      const createResult = isValid => {
+        const { parseValue } = this.props;
+
+        if (typeof parseValue !== 'function') {
+          throw Error('ParseValue should be function');
+        }
+
+        return {
+          isValid,
+          value: parseValue(this.props.value),
+          name: this.props.name,
+        };
+      };
       if (errorMessages.length > 0) {
         this.mergeFields({ errorMessages });
         return Promise.resolve(createResult(false));

--- a/test/__snapshots__/_createField.test.js.snap
+++ b/test/__snapshots__/_createField.test.js.snap
@@ -40,6 +40,7 @@ exports[`field container should create field component 1`] = `
       "foo",
     ]
   }
+  parseValue={[Function]}
   registerAsyncValidators={[Function]}
   registerChangeValidators={[Function]}
   registerSubmitValidators={[Function]}

--- a/test/_createField.test.js
+++ b/test/_createField.test.js
@@ -88,4 +88,31 @@ describe('field container', () => {
       __fieldNames: fieldNames,
     }).toMatchSnapshot();
   });
+
+  it('should return value correctly', async () => {
+    renderer.render(<FieldContainer {...props} value={'my value'} />);
+
+    expect(await fields[props.name].validateAll()).toEqual({
+      isValid: true,
+      name: ['foo'],
+      value: 'my value'
+    });
+  });
+
+  it('should throw error parseValue is not a function', async () => {
+    renderer.render(<FieldContainer {...props} value='test' parseValue={'test'} />);
+    await expect(fields[props.name].validateAll()).rejects.toEqual(expect.any(Error))
+  });
+
+  it('should call parseValue correctly', async () => {
+    const parseValue = jest.fn().mockImplementation(value => value.id);
+    renderer.render(<FieldContainer {...props} value={{ id: '1234', text: 'Testing' }} parseValue={parseValue} />);
+
+    expect(await fields[props.name].validateAll()).toEqual({
+      isValid: true,
+      name: ['foo'],
+      value: '1234'
+    });
+    expect(parseValue).toBeCalled();
+  });
 });


### PR DESCRIPTION
**Background:** 
Sometime we'll need to re-format the value after invoking `form.submit`. This could be real pain if we have an customized field that accept object as value in nested repeatable.

**Propose:**
Add options parameter to createField, which is an object. using object for any future development that might need to pass a new parameter. currently only passing `parseValue`, which will be invoked on `validateAll`