### PR TITLE
[FIX] Bug on validation with more than one form

### DIFF
--- a/src/_createForm.js
+++ b/src/_createForm.js
@@ -22,8 +22,8 @@ import {
 } from './_utils';
 
 export const __createForm = (fields, fieldNames) => (formId, dispatch) => {
-  const __fields = fields;
-  const __fieldNames = fieldNames;
+  const __fields = fields || {};
+  const __fieldNames = fieldNames || [];
   const actionCreators = {
     lockSubmission: () => setFormIsSubmittingState(formId, true),
     unlockSubmission: () => setFormIsSubmittingState(formId, false),
@@ -137,7 +137,7 @@ export const __createForm = (fields, fieldNames) => (formId, dispatch) => {
   };
 };
 
-export const _createForm = __createForm({}, []);
+export const _createForm = __createForm();
 
 export default formId => Component => {
   class CreateForm extends React.Component {


### PR DESCRIPTION
When more than one form exist, and one of them submit. form not only validate submitted form but also another form across the same store.

Cause of the bug is components shared fields across forms.

Solution
Add conditional default value to __fields and __fieldNames. So when initializing new form, fields and fieldNames set with new object.