### PR TITLE
Allow repeatable to have 0 minimum length

### DIFF
--- a/src/createRepeatable.js
+++ b/src/createRepeatable.js
@@ -20,7 +20,7 @@ const mapStateToProps = (state, props) => {
   const fieldNames = getFieldNames(props.name);
   const selector = createSelector(state, props.form.getFormId());
   const length = selector.getLength(fieldNames);
-  const minLength = props.minLength || 1;
+  const minLength = (typeof props.minLength === 'number') && props.minLength >= 0 ? props.minLength : 1;
 
   return {
     length: length >= minLength ? length : minLength,


### PR DESCRIPTION
**Issue:**
In createRepeatable, component will render a minimum of 1 children when the store is an empty array, even when minLength is passed as 0.

**Cause:**
Incorrect state mapping in redux's connect.