### PR TITLE
Fix: unselected checkbox will return '' instead of false

### DIFF
--- a/src/createField.js
+++ b/src/createField.js
@@ -34,7 +34,7 @@ const mapStateToProps = (state, props) => {
     isFieldEnabled: field.isEnabled,
     isValidating: field.isValidating,
     touched: field.touched,
-    value: field.value || '',
+    value: typeof(field.value) === 'undefined' || field.value === null ? '' : field.value
   };
 };
 /* eslint-enable complexity */


### PR DESCRIPTION
Caused by previous fix: https://github.com/traveloka/soya-form/pull/15. Previous change will return every false value with empty string, which is incorrect, the logic should be checking for undefined or null only.