### PR TITLE
Fix: mergeFields should reflect the value in store

### DIFF
--- a/src/_createField.js
+++ b/src/_createField.js
@@ -160,6 +160,7 @@ export default Component => {
       const {
         changeValidators,
         asyncValidators,
+        value,
         ...props
       } = this.props;
       delete props.createHandleChange;
@@ -183,6 +184,7 @@ export default Component => {
       props.registerChangeValidators = this.registerChangeValidators;
       props.registerAsyncValidators = this.registerAsyncValidators;
       props.registerSubmitValidators = this.registerSubmitValidators;
+      props.value = typeof(value) === 'undefined' || value === null ? '' : value;
 
       return <Component {...props} />;
     }

--- a/src/createField.js
+++ b/src/createField.js
@@ -17,7 +17,6 @@ import {
 import withForm from './withForm';
 import _createField from './_createField';
 
-/* eslint-disable complexity */
 const mapStateToProps = (state, props) => {
   const formId = props.form.getFormId();
   const fieldNames = getFieldNames(props.name);
@@ -34,10 +33,9 @@ const mapStateToProps = (state, props) => {
     isFieldEnabled: field.isEnabled,
     isValidating: field.isValidating,
     touched: field.touched,
-    value: typeof(field.value) === 'undefined' || field.value === null ? '' : field.value
+    value: field.value
   };
 };
-/* eslint-enable complexity */
 
 const mapDispatchToProps = (dispatch, props) => ({
   mergeFields: fieldNames => object => {


### PR DESCRIPTION
This is cause by previous fix, the object checking should be done in `_createField` instead of `createField`. this causes value set in store is not reflected when `form.submit` is invoked. Instead, its returning the value set in the component itself. The source of truth for field value should be redux store instead of component value.