### PR TITLE
[FIX] Custom repeatable tag

### DIFF
--- a/src/_createRepeatable.js
+++ b/src/_createRepeatable.js
@@ -24,10 +24,12 @@ export default Component => hoistStatics(class extends React.Component {
     reorderListItem: PropTypes.func.isRequired,
     reorderListItemDec: PropTypes.func.isRequired,
     reorderListItemInc: PropTypes.func.isRequired,
+    tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   };
 
   static defaultProps = {
     minLength: 0,
+    tag: 'div'
   };
 
   addListItem = () => {
@@ -47,11 +49,16 @@ export default Component => hoistStatics(class extends React.Component {
   reorderListItemInc = (index, amount) => this.props.reorderListItemInc(this.props.name)(index, amount);
 
   render() {
+    const {
+      tag: Tag,
+      ...props
+    } = this.props;
+
     return (
-      <div>
+      <Tag>
         {new Array(this.props.length).fill(null).map((_, index) => (
           <Component
-            {...this.props}
+            {...props}
             index={index}
             key={index}
             name={createGetName(this.props.name, index)}
@@ -63,7 +70,7 @@ export default Component => hoistStatics(class extends React.Component {
             reorderListItemInc={this.reorderListItemInc}
           />
         ))}
-      </div>
+      </Tag>
     );
   }
 }, Component);


### PR DESCRIPTION
# Background

I need to use repeateable inside a table with expected structure look like this
```
<table>
  <tbody>
    <tr></tr> /* this tr is repeated */
    <tr></tr> /* this tr is repeated */
  </tbody>
</table>
```

# Pain point
turns out that `_createRepeatable` will wrap another `div` outside of what is repeated, which will be like this
```
<table>
  <tbody>
    <div> /* from _createRepeatable */
      <tr></tr> /* this tr is repeated */
      <tr></tr> /* this tr is repeated */
    </div>
  </tbody>
</table>
```

which of course will trigger `validateDomNesting` warning `<tr> cannot appear as a child of <div>` and make the rendered component look like an absolute mess
![image](https://user-images.githubusercontent.com/14540711/41086254-9fcb1a18-6a63-11e8-9125-6843e1c623b6.png)

# Proposal
support custom "parent tag" to eliminate previous issues by adding `tag` props onto `_createRepeatable` container, and hopefully resulting this

```
<table>
  <tbody> /* from _createRepeatable using tag props */
    <tr></tr> /* this tr is repeated */
    <tr></tr> /* this tr is repeated */
  </tbody>
</table>
```