### PR TITLE
[FEATURE] Add utility to convert server response to soya-form format

### DIFF
--- a/src/getSoyaFormFormat.js
+++ b/src/getSoyaFormFormat.js
@@ -1,0 +1,70 @@
+import isArray from "lodash/isArray";
+import isObject from "lodash/isObject";
+import isPlainObject from "lodash/isPlainObject";
+
+export const transformObject = (operand, parentKeys) => {
+  return Object.keys(operand).reduce((carry, key) => {
+    // primitive value see: https://github.com/lodash/lodash/issues/1406
+    if (!isObject(operand[key])) {
+      return [
+        ...carry,
+        { fieldName: [...parentKeys, key], value: operand[key] }
+      ];
+    }
+
+    // Array value
+    if (isArray(operand[key])) {
+      return [...carry, ...transformArray(operand[key], [...parentKeys, key])];
+    }
+
+    // Object value
+    if (isPlainObject(operand[key])) {
+      return [...carry, ...transformObject(operand[key], [...parentKeys, key])];
+    }
+
+    return carry;
+  }, []);
+};
+
+export const transformArray = (operand, parentKeys) => {
+  return operand.reduce((carry, arrayItem, currIdx) => {
+    // primitive value see: https://github.com/lodash/lodash/issues/1406
+    if (!isObject(arrayItem)) {
+      return [
+        ...carry,
+        { fieldName: [...parentKeys, currIdx], value: arrayItem }
+      ];
+    }
+
+    // Object value
+    if (isPlainObject(arrayItem)) {
+      return [
+        ...carry,
+        ...transformObject(arrayItem, [...parentKeys, currIdx])
+      ];
+    }
+
+    return carry;
+  }, []);
+};
+
+export const transform = (object, parentKeys) => {
+  return Object.keys(object).reduce((carry, key) => {
+    // primitive value see: https://github.com/lodash/lodash/issues/1406
+    if (!isObject(object[key])) {
+      return [...carry, { fieldName: key, value: object[key] }];
+    }
+
+    // Array value
+    if (isArray(object[key])) {
+      return [...carry, ...transformArray(object[key], [key])];
+    }
+
+    // Object value
+    if (isPlainObject(object[key])) {
+      return [...carry, ...transformObject(object[key], [key])];
+    }
+
+    return carry;
+  }, []);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
-import createForm from './createForm';
-import createField from './createField';
-import createRepeatable from './createRepeatable';
-import createSelector from './_selectors';
-import withForm from './withForm';
-import withFormValues from './withFormValues';
+import createForm from "./createForm";
+import createField from "./createField";
+import createRepeatable from "./createRepeatable";
+import createSelector from "./_selectors";
+import withForm from "./withForm";
+import withFormValues from "./withFormValues";
+import { transform as getSoyaFormFormat } from "./getSoyaFormFormat";
 
 export {
   createForm,
@@ -12,4 +13,5 @@ export {
   createSelector,
   withForm,
   withFormValues,
+  getSoyaFormFormat
 };

--- a/test/getSoyaFormFormat.test.js
+++ b/test/getSoyaFormFormat.test.js
@@ -1,0 +1,181 @@
+import {
+  transform,
+  transformObject,
+  transformArray
+} from "../src/getSoyaFormFormat";
+
+const exampleObjectInput = {
+  simple: "value",
+  nested: {
+    simple: "value"
+  },
+  deep: {
+    nested: {
+      complex: "value"
+    }
+  },
+  simpleArray: ["1"],
+  nestedWith: {
+    simpleArray: [1, 3]
+  }
+};
+
+const exampleArrayInput = [
+  "test",
+  1,
+  {
+    objectInsideArray: {
+      nested: {
+        complex: "value"
+      },
+      andHaveArray: [
+        1,
+        {
+          anotherComplexObjToo: "one"
+        }
+      ]
+    }
+  }
+];
+
+const exampleMixedInput = {
+  simple: "simple value",
+  array: [1, 2, 3],
+  boolean: true,
+  fieldNull: null,
+  nested: {
+    object: "nested object",
+    test: ["again", 1, 2]
+  },
+  another: {
+    deep: {
+      nested: {
+        obj: "val"
+      },
+      sibling: 2
+    }
+  },
+  arrayOfObject: [
+    {
+      name: "a",
+      value: "b",
+      nested: ["array again"]
+    },
+    {
+      name: "c",
+      value: "d",
+      differentKey: "e"
+    }
+  ]
+};
+
+describe("getSoyaFormFormat", () => {
+  describe("transformObject", () => {
+    test("with empty parentKeys", () => {
+      expect(transformObject(exampleObjectInput, [])).toEqual([
+        { fieldName: ["simple"], value: "value" },
+        { fieldName: ["nested", "simple"], value: "value" },
+        { fieldName: ["deep", "nested", "complex"], value: "value" },
+        { fieldName: ["simpleArray", 0], value: "1" },
+        { fieldName: ["nestedWith", "simpleArray", 0], value: 1 },
+        { fieldName: ["nestedWith", "simpleArray", 1], value: 3 }
+      ]);
+    });
+
+    test("with Non-empty parentKeys", () => {
+      expect(transformObject(exampleObjectInput, ["base"])).toEqual([
+        { fieldName: ["base", "simple"], value: "value" },
+        { fieldName: ["base", "nested", "simple"], value: "value" },
+        { fieldName: ["base", "deep", "nested", "complex"], value: "value" },
+        { fieldName: ["base", "simpleArray", 0], value: "1" },
+        { fieldName: ["base", "nestedWith", "simpleArray", 0], value: 1 },
+        { fieldName: ["base", "nestedWith", "simpleArray", 1], value: 3 }
+      ]);
+    });
+  });
+
+  describe("transformArray", () => {
+    test("with empty parentKeys", () => {
+      expect(transformArray(exampleArrayInput, [])).toEqual([
+        { fieldName: [0], value: "test" },
+        { fieldName: [1], value: 1 },
+        {
+          fieldName: [2, "objectInsideArray", "nested", "complex"],
+          value: "value"
+        },
+        {
+          fieldName: [2, "objectInsideArray", "andHaveArray", 0],
+          value: 1
+        },
+        {
+          fieldName: [
+            2,
+            "objectInsideArray",
+            "andHaveArray",
+            1,
+            "anotherComplexObjToo"
+          ],
+          value: "one"
+        }
+      ]);
+    });
+
+    test("with Non-empty parentKeys", () => {
+      expect(transformArray(exampleArrayInput, ["base"])).toEqual([
+        { fieldName: ["base", 0], value: "test" },
+        { fieldName: ["base", 1], value: 1 },
+        {
+          fieldName: ["base", 2, "objectInsideArray", "nested", "complex"],
+          value: "value"
+        },
+        {
+          fieldName: ["base", 2, "objectInsideArray", "andHaveArray", 0],
+          value: 1
+        },
+        {
+          fieldName: [
+            "base",
+            2,
+            "objectInsideArray",
+            "andHaveArray",
+            1,
+            "anotherComplexObjToo"
+          ],
+          value: "one"
+        }
+      ]);
+    });
+  });
+
+  describe("transform", () => {
+    expect(transform(exampleMixedInput)).toEqual([
+      { fieldName: "simple", value: "simple value" },
+      { fieldName: ["array", 0], value: 1 },
+      { fieldName: ["array", 1], value: 2 },
+      { fieldName: ["array", 2], value: 3 },
+      { fieldName: "boolean", value: true },
+      { fieldName: "fieldNull", value: null },
+      { fieldName: ["nested", "object"], value: "nested object" },
+      { fieldName: ["nested", "test", 0], value: "again" },
+      { fieldName: ["nested", "test", 1], value: 1 },
+      { fieldName: ["nested", "test", 2], value: 2 },
+      {
+        fieldName: ["another", "deep", "nested", "obj"],
+        value: "val"
+      },
+      { fieldName: ["another", "deep", "sibling"], value: 2 },
+      { fieldName: ["arrayOfObject", 0, "name"], value: "a" },
+      { fieldName: ["arrayOfObject", 0, "value"], value: "b" },
+      {
+        fieldName: ["arrayOfObject", 0, "nested", 0],
+        value: "array again"
+      },
+      { fieldName: ["arrayOfObject", 1, "name"], value: "c" },
+      { fieldName: ["arrayOfObject", 1, "value"], value: "d" },
+      {
+        fieldName: ["arrayOfObject", 1, "differentKey"],
+        value: "e"
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
# What it is ?
Sometimes you retrieve a value from server and you want to populate each Soya-Form field with the server response. Off course, this is a repetitive work. Assuming that most of the fields store the value in plain format (not object or array) , we can use this utils function.

```
const exampleServerResponse = {
  simple: "value",
  nested: {
    simple: "value"
  },
  deep: {
    nested: {
      complex: "value"
    }
  },
  simpleArray: ["1"],
  nestedWith: {
    simpleArray: [1, 3]
  }
};

console.log(transform(exampleServerResponse))

// output : 
[ { fieldName: 'simple', value: 'value' },
  { fieldName: [ 'nested', 'simple' ], value: 'value' },
  { fieldName: [ 'deep', 'nested', 'complex' ], value: 'value' },
  { fieldName: [ 'simpleArray', 0 ], value: '1' },
  { fieldName: [ 'nestedWith', 'simpleArray', 0 ], value: 1 },
  { fieldName: [ 'nestedWith', 'simpleArray', 1 ], value: 3 } ]
```

# Limitation
If you have a soya-form field component which store its value in object / array, then you should handle this manually. Or contribute to this 'base' simple utilty :smile: 

For example,
1. [CheckboxField](https://tvlk-b2b-ui.firebaseapp.com/?selectedKind=Components%2FCheckbox&selectedStory=examples%20%2B%20proptypes&full=0&addons=0&stories=1&panelRight=0) in Extranet store its value as array,
2. [GoogleMapsInputField](https://tvlk-b2b-ui.firebaseapp.com/?selectedKind=Components%2FGoogleMaps&selectedStory=advanced%20example&full=0&addons=0&stories=1&panelRight=0) in Extranet store its value as object of latitude and longitude.